### PR TITLE
Issue 3/jupyter ipykernel

### DIFF
--- a/jupyter_ipykernel/README.md
+++ b/jupyter_ipykernel/README.md
@@ -1,0 +1,32 @@
+# jupyter ipykernel
+
+Install jupyter and the ipykernel in your environment
+
+```bash
+# ipykernel installs all dependencies needed to use jupyter
+conda env create -f jupyter_ipykernel/environment.yaml
+conda activate jupyter_a
+```
+
+Looking around
+
+```bash
+conda env list
+conda info --envs
+
+conda list -n jupyter_a
+conda env export --from-history
+```
+
+Installs the kernel for this environment
+
+```bash
+python -m ipykernel install --user --name=jupyter_a
+```
+
+Manage jupyter ipykernel
+
+```bash
+jupyter kernelspec list
+jupyter kernelspec remove <my-env>
+```

--- a/jupyter_ipykernel/demo.ipynb
+++ b/jupyter_ipykernel/demo.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bee2546-a726-4b40-ae9f-0a7fd1e39b6a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import catplotlib.catplot as clt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98df33a3-779f-404a-9494-9c2c9c371695",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clt.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d81b8c5-986b-4584-b864-4f9f8c695636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clt.plot(says='matplotlib + cats = catplotlib')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f47e8139-0430-41a2-a68a-aebafbb1633a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter_ipykernel/environment.yaml
+++ b/jupyter_ipykernel/environment.yaml
@@ -1,0 +1,11 @@
+name: jupyter_a
+channels:
+  - conda-forge
+dependencies:
+  - ipykernel
+  - jupyter
+  - jupyterlab
+  - matplotlib
+  - pip
+  - pip:
+      - catplotlib


### PR DESCRIPTION
Resolves #3.

Add contents for Jupyter IPython kernel:
- Add README.md with setup instructions
- Include environment.yaml for dependencies
- Provide demo notebook (demo.ipynb) for usage examples